### PR TITLE
add jython@2.5.3

### DIFF
--- a/Formula/jython@2.5.3.rb
+++ b/Formula/jython@2.5.3.rb
@@ -1,6 +1,6 @@
 class JythonAT253 < Formula
   desc "Python implementation written in Java (successor to JPython)"
-  homepage "http://www.jython.org"
+  homepage "https://www.jython.org/"
   url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar"
   sha256 "05405966cdfa57abc8e705dd6aab92b8240097ce709fb916c8a0dbcaa491f99e"
 

--- a/Formula/jython@2.5.3.rb
+++ b/Formula/jython@2.5.3.rb
@@ -1,0 +1,18 @@
+class JythonAT253 < Formula
+  desc "Python implementation written in Java (successor to JPython)"
+  homepage "http://www.jython.org"
+  url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar"
+  sha256 "05405966cdfa57abc8e705dd6aab92b8240097ce709fb916c8a0dbcaa491f99e"
+
+  # This isn't accidental; there is actually a compile process here.
+  def install
+    system "java", "-jar", cached_download, "-s", "-d", libexec
+    bin.install_symlink libexec/"bin/jython"
+  end
+
+  test do
+    jython = shell_output("#{bin}/jython -c \"from java.util import Date; print Date()\"")
+    # This will break in the year 2100. The test will need updating then.
+    assert_match jython.match(/20\d\d/).to_s, shell_output("/bin/date +%Y")
+  end
+end


### PR DESCRIPTION
Jython 2.5.3 is used in Igniton 7.9 and is needed for development.