### PR TITLE
fix(formula): update ignition

### DIFF
--- a/Formula/ignition.rb
+++ b/Formula/ignition.rb
@@ -12,8 +12,6 @@ class Ignition < Formula
     regex(/"version"\s*:\s*"(\d+(:?\.\d+)*)"/i)
   end
 
-  bottle :unneeded
-
   def install
     # Relocate data
     mv "data", "ignition"
@@ -31,6 +29,11 @@ class Ignition < Formula
     # Make files executable
     %w[gwcmd.sh ignition.sh ignition-util.sh ignition-gateway].each do |cmd|
       chmod "u=wrx,go=rx", "#{libexec}/#{cmd}"
+    end
+
+    # Update com.inductiveautomation.ignition.plist
+    inreplace "#{libexec}/com.inductiveautomation.ignition.plist" do |s|
+      s.gsub! "<string>com.inductiveautomation.ignition</string>", "<string>#{plist_name}</string>"
     end
 
     # Create symlinks

--- a/Formula/ignition@7.9.rb
+++ b/Formula/ignition@7.9.rb
@@ -12,8 +12,6 @@ class IgnitionAT79 < Formula
     regex(/"version"\s*:\s*"(7.9(:?\.\d+)*)"/i)
   end
 
-  bottle :unneeded
-
   depends_on "openjdk@8"
 
   def install
@@ -38,6 +36,7 @@ class IgnitionAT79 < Formula
     # Update com.inductiveautomation.ignition.plist
     inreplace "#{libexec}/com.inductiveautomation.ignition.plist" do |s|
       s.gsub! "/usr/local/bin/ignition", "/usr/local/bin/ignition7.9"
+      s.gsub! "<string>com.inductiveautomation.ignition</string>", "<string>#{plist_name}</string>"
     end
 
     # Create symlinks

--- a/Formula/ignition@8.0.rb
+++ b/Formula/ignition@8.0.rb
@@ -12,8 +12,6 @@ class IgnitionAT80 < Formula
     regex(/"version"\s*:\s*"(8.0(:?\.\d+)*)"/i)
   end
 
-  bottle :unneeded
-
   def install
     # Relocate data
     mv "data", "ignition8.0"
@@ -36,6 +34,7 @@ class IgnitionAT80 < Formula
     # Update com.inductiveautomation.ignition.plist
     inreplace "#{libexec}/com.inductiveautomation.ignition.plist" do |s|
       s.gsub! "/usr/local/bin/ignition", "/usr/local/bin/ignition8.0"
+      s.gsub! "<string>com.inductiveautomation.ignition</string>", "<string>#{plist_name}</string>"
     end
 
     # Create symlinks


### PR DESCRIPTION
fixes
* Running brew services [re]start results in error [Homebrew/homebrew-services#376](https://github.com/Homebrew/homebrew-services/issues/376)
* Warning: Calling bottle :unneeded is deprecated! There is no replacement.

Signed-off-by: César Román <thecesrom@gmail.com>