### PR TITLE
fix(formula): add `version` stanza to `ignition`

### DIFF
--- a/Formula/ignition.rb
+++ b/Formula/ignition.rb
@@ -3,6 +3,7 @@ class Ignition < Formula
   homepage "https://inductiveautomation.com/"
   url "https://files.inductiveautomation.com/release/ia/8.1.15/20220301-1426/Ignition-macOs-x86-64-8.1.15.zip",
       referer: "https://inductiveautomation.com/"
+  version "8.1.15"
   sha256 "24331d78e843421807040e10455f10efd6bdd4f79dee1d603510d370773fd8a0"
   license :cannot_represent
 


### PR DESCRIPTION
The change in the `url` introduced by #37 broke the `version` and it was mistakenly extracted as `64-8` instead of `8.1.15`.

Signed-off-by: César Román <thecesrom@gmail.com>