### PR TITLE
ci: update tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - coatl
+    paths:
+      - '**.rb'
+      - .github/workflows/tests.yml
   pull_request:
+    paths:
+      - '**.rb'
+      - .github/workflows/tests.yml
 jobs:
   test-bot:
     strategy:


### PR DESCRIPTION
run `brew test-bot` only when `formulae` or `casks` have been modified