### PR TITLE
feat(formula): deprecate `ignition@8.0`

### DIFF
--- a/Formula/ignition@8.0.rb
+++ b/Formula/ignition@8.0.rb
@@ -47,8 +47,9 @@ class IgnitionAT80 < Formula
   end
 
   def post_install
+    # Relocate files
     %w[License.html Notice.txt README.txt].each do |f|
-      libexec.install "#{prefix}/#{f}"
+      libexec.install "#{prefix}/#{f}" if File.exist?("#{prefix}/#{f}")
     end
 
     # Unzip the new runtime

--- a/Formula/ignition@8.0.rb
+++ b/Formula/ignition@8.0.rb
@@ -12,6 +12,8 @@ class IgnitionAT80 < Formula
     regex(/"version"\s*:\s*"(8.0(:?\.\d+)*)"/i)
   end
 
+  deprecate! date: "2020-11-12", because: :unmaintained
+
   def install
     # Relocate data
     mv "data", "ignition8.0"


### PR DESCRIPTION
Ignition 8.0's last release occurred in 2020-11-12, and its last "nightly" build was in 2021-01-07.

Signed-off-by: César Román <thecesrom@gmail.com>