### PR TITLE
refactor(formula): simplify ignition@8.0 post_install

### DIFF
--- a/Formula/ignition@8.0.rb
+++ b/Formula/ignition@8.0.rb
@@ -51,19 +51,6 @@ class IgnitionAT80 < Formula
     %w[License.html Notice.txt README.txt].each do |f|
       libexec.install "#{prefix}/#{f}" if File.exist?("#{prefix}/#{f}")
     end
-
-    # Unzip the new runtime
-    system "tar", "-C", "#{libexec}/lib/runtime", "-xf", "#{libexec}/lib/runtime/jre-mac.tar.gz"
-
-    # Update ignition.conf
-    system "#{libexec}/lib/runtime/jre-mac/bin/java",
-           "-classpath",
-           "#{libexec}/lib/core/common/common.jar",
-           "com.inductiveautomation.ignition.common.upgrader.Upgrader",
-           libexec.to_s,
-           "#{libexec}/data",
-           "#{libexec}/logs",
-           "file=ignition.conf"
   end
 
   def caveats


### PR DESCRIPTION
There is no need to upgrade ignition.conf

According to `README.txt` instructions on upgrading an existing installation:

```plain text
7) If this is a major version upgrade (8.0 to 8.1) then the data/ignition.conf file may have changed. If this is a minor version upgrade (8.0.1 to 8.0.2) then skip to step 8.
```

This formula will not install a major version upgrade, only minor version upgrades for `8.0`.