### PR TITLE
ignition@8.3: fix persisted modules.json

### DIFF
--- a/Formula/ignition@8.3.rb
+++ b/Formula/ignition@8.3.rb
@@ -15,6 +15,7 @@ class IgnitionAT83 < Formula
   version "8.3.0-beta4"
   sha256 sha.to_s
   license :cannot_represent
+  revision 1
 
   livecheck do
     url "https://inductiveautomation.com/downloads/ignition/"
@@ -24,9 +25,13 @@ class IgnitionAT83 < Formula
 
   def install
     # Relocate data
-    (etc/"ignition/8.3").mkpath unless (etc/"ignition/8.3/data").exist?
-    etc.install "data" => "ignition/8.3/data" unless (etc/"ignition/8.3/data").exist?
+    etc_dir = etc/"ignition/8.3"
+    data_dir = etc/"ignition/8.3/data"
+    modules_json = etc/"ignition/8.3/data/modules.json"
+    etc_dir.mkpath unless data_dir.exist?
+    etc.install "data" => data_dir unless data_dir.exist?
     rm_r "data"
+    rm modules_json if data_dir.exist? && modules_json.exist?
 
     # Relocate logs
     (var/"ignition/8.3/logs").mkpath unless (var/"ignition/8.3/logs").exist?


### PR DESCRIPTION
When upgrading from a previous version, persisted modules.json points to
the previous location.

Example:

When upgrading from beta3 to beta4, modules.json is persisted and
pointing to this invalid location:

/opt/homebrew/Cellar/ignition@8.3/8.3.0-beta3/libexec/user-lib/modules

The intention is that by removing modules.json, this file will be
recreated on start up.
